### PR TITLE
#38 Java 15 Upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
     morpher-executor:
         docker:
-            - image: szgabsz91/jdk-ocamorph-pyphen:14.0.0
+            - image: szgabsz91/jdk-ocamorph-pyphen:15.0.0
         working_directory: ~/morpher
 
 jobs:

--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,19 @@
 buildscript {
     ext {
         morpherGroupId = 'com.github.szgabsz91'
-        morpherVersion = '1.2.1-SNAPSHOT'
+        morpherVersion = '1.3.0-SNAPSHOT'
 
         bintrayKey = System.getenv('BINTRAY_KEY')
         mavenCentralPassword = System.getenv('MAVEN_CENTRAL_PASSWORD')
         buildNumber = System.getenv('CIRCLE_BUILD_NUM')
 
-        javaVersion = '14'
+        javaVersion = '15'
 
         buildInfoExtractorGradleVersion = 'latest.release'
-        checkstyleVersion = '8.36'
+        checkstyleVersion = '8.36.1'
         gradleBintrayPluginVersion = '1.8.5'
         guavaVersion = '29.0-jre'
-        jacocoVersion = '0.8.5'
+        jacocoVersion = '0.8.6'
         pmdVersion = '6.27.0'
         protobufGradlePluginVersion = '0.8.13'
         protocVersion = '3.13.0'
@@ -32,9 +32,9 @@ buildscript {
         velocityVersion = '2.2'
         zip4jVersion = '1.3.3'
 
-        assertjVersion = '3.17.1'
-        junitJupiterVersion = '5.6.2'
-        junitPlatformVersion = '1.6.2'
+        assertjVersion = '3.17.2'
+        junitJupiterVersion = '5.7.0'
+        junitPlatformVersion = '1.7.0'
         mockitoVersion = '3.5.10'
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
         protobufGradlePluginVersion = '0.8.13'
         protocVersion = '3.13.0'
         spotbugsVersion = '4.1.2'
-        spotbugsGradlePluginVersion = '2.0.0'
+        spotbugsGradlePluginVersion = '4.5.0'
 
         combinatoricslibVersion = '3.3.0'
         commonsCollectionsVersion = '4.4'
@@ -48,7 +48,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "gradle.plugin.com.github.spotbugs:spotbugs-gradle-plugin:${spotbugsGradlePluginVersion}"
+        classpath "gradle.plugin.com.github.spotbugs.snom:spotbugs-gradle-plugin:${spotbugsGradlePluginVersion}"
         classpath "com.google.protobuf:protobuf-gradle-plugin:${protobufGradlePluginVersion}"
         // Workaround for Spotbugs vs Protobuf:
         // - https://github.com/spotbugs/spotbugs-gradle-plugin/issues/120

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -39,7 +39,7 @@ afterEvaluate {
 
     tasks.withType(Javadoc) {
         source = sourceSets.main.allJava + file('build/generated/source/proto/main/java')
-        options.addStringOption('-module-path', classpath.asPath.toString())
+        options.modulePath([file(classpath.asPath)])
         build.dependsOn it
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/morpher-core/gradle/wrapper/gradle-wrapper.properties
+++ b/morpher-core/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/morpher-core/gradle/wrapper/gradle-wrapper.properties
+++ b/morpher-core/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/morpher-engines/morpher-engine-api/gradle/wrapper/gradle-wrapper.properties
+++ b/morpher-engines/morpher-engine-api/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/morpher-engines/morpher-engine-api/gradle/wrapper/gradle-wrapper.properties
+++ b/morpher-engines/morpher-engine-api/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/morpher-engines/morpher-engine-hunmorph/gradle/wrapper/gradle-wrapper.properties
+++ b/morpher-engines/morpher-engine-hunmorph/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/morpher-engines/morpher-engine-hunmorph/gradle/wrapper/gradle-wrapper.properties
+++ b/morpher-engines/morpher-engine-hunmorph/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/morpher-engines/morpher-engine-impl/gradle/wrapper/gradle-wrapper.properties
+++ b/morpher-engines/morpher-engine-impl/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/morpher-engines/morpher-engine-impl/gradle/wrapper/gradle-wrapper.properties
+++ b/morpher-engines/morpher-engine-impl/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/morpher-language-handlers/morpher-language-handler-api/gradle/wrapper/gradle-wrapper.properties
+++ b/morpher-language-handlers/morpher-language-handler-api/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/morpher-language-handlers/morpher-language-handler-api/gradle/wrapper/gradle-wrapper.properties
+++ b/morpher-language-handlers/morpher-language-handler-api/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/morpher-language-handlers/morpher-language-handler-hunmorph/gradle/wrapper/gradle-wrapper.properties
+++ b/morpher-language-handlers/morpher-language-handler-hunmorph/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/morpher-language-handlers/morpher-language-handler-hunmorph/gradle/wrapper/gradle-wrapper.properties
+++ b/morpher-language-handlers/morpher-language-handler-hunmorph/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/morpher-systems/morpher-system-api/gradle/wrapper/gradle-wrapper.properties
+++ b/morpher-systems/morpher-system-api/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/morpher-systems/morpher-system-api/gradle/wrapper/gradle-wrapper.properties
+++ b/morpher-systems/morpher-system-api/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/morpher-systems/morpher-system-impl/gradle/wrapper/gradle-wrapper.properties
+++ b/morpher-systems/morpher-system-impl/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/morpher-systems/morpher-system-impl/gradle/wrapper/gradle-wrapper.properties
+++ b/morpher-systems/morpher-system-impl/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/morpher-transformation-engines/morpher-transformation-engine-api/build.gradle
+++ b/morpher-transformation-engines/morpher-transformation-engine-api/build.gradle
@@ -8,7 +8,7 @@ ext {
     moduleName = 'com.github.szgabsz91.morpher.transformationengines.api'
 
     testCoverageLimits = [
-        instruction: 99.77,
+        instruction: 99.75,
         line: 99.69,
         branch: 99.17,
         class: 100.0

--- a/morpher-transformation-engines/morpher-transformation-engine-api/gradle/wrapper/gradle-wrapper.properties
+++ b/morpher-transformation-engines/morpher-transformation-engine-api/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/morpher-transformation-engines/morpher-transformation-engine-api/gradle/wrapper/gradle-wrapper.properties
+++ b/morpher-transformation-engines/morpher-transformation-engine-api/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/morpher-transformation-engines/morpher-transformation-engine-astra/build.gradle
+++ b/morpher-transformation-engines/morpher-transformation-engine-astra/build.gradle
@@ -8,7 +8,7 @@ ext {
     moduleName = 'com.github.szgabsz91.morpher.transformationengines.astra'
     mockingEnabled = true
     testCoverageLimits = [
-        instruction: 98.32,
+        instruction: 98.31,
         line: 98.64,
         branch: 94.62,
         class: 100.0

--- a/morpher-transformation-engines/morpher-transformation-engine-astra/gradle/wrapper/gradle-wrapper.properties
+++ b/morpher-transformation-engines/morpher-transformation-engine-astra/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/morpher-transformation-engines/morpher-transformation-engine-astra/gradle/wrapper/gradle-wrapper.properties
+++ b/morpher-transformation-engines/morpher-transformation-engine-astra/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/morpher-transformation-engines/morpher-transformation-engine-dictionary/gradle/wrapper/gradle-wrapper.properties
+++ b/morpher-transformation-engines/morpher-transformation-engine-dictionary/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/morpher-transformation-engines/morpher-transformation-engine-dictionary/gradle/wrapper/gradle-wrapper.properties
+++ b/morpher-transformation-engines/morpher-transformation-engine-dictionary/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/morpher-transformation-engines/morpher-transformation-engine-fst/gradle/wrapper/gradle-wrapper.properties
+++ b/morpher-transformation-engines/morpher-transformation-engine-fst/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/morpher-transformation-engines/morpher-transformation-engine-fst/gradle/wrapper/gradle-wrapper.properties
+++ b/morpher-transformation-engines/morpher-transformation-engine-fst/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/morpher-transformation-engines/morpher-transformation-engine-lattice/build.gradle
+++ b/morpher-transformation-engines/morpher-transformation-engine-lattice/build.gradle
@@ -9,7 +9,7 @@ ext {
     mockingEnabled = true
 
     testCoverageLimits = [
-        instruction: 98.34,
+        instruction: 98.33,
         line: 98.94,
         branch: 96.33,
         class: 100.0

--- a/morpher-transformation-engines/morpher-transformation-engine-lattice/gradle/wrapper/gradle-wrapper.properties
+++ b/morpher-transformation-engines/morpher-transformation-engine-lattice/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/morpher-transformation-engines/morpher-transformation-engine-lattice/gradle/wrapper/gradle-wrapper.properties
+++ b/morpher-transformation-engines/morpher-transformation-engine-lattice/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/morpher-transformation-engines/morpher-transformation-engine-tasr/gradle/wrapper/gradle-wrapper.properties
+++ b/morpher-transformation-engines/morpher-transformation-engine-tasr/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/morpher-transformation-engines/morpher-transformation-engine-tasr/gradle/wrapper/gradle-wrapper.properties
+++ b/morpher-transformation-engines/morpher-transformation-engine-tasr/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- [x] Upgrade Gradle to version 6.7 when the stable release is available
- [x] Make sure that the Javadoc is properly generated during the pipeline
- [x] Upgrade Spotbugs by the time it supports Java 15